### PR TITLE
Fix npm create command for npm 11 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ See Convex docs at https://docs.convex.dev/home
 ## Setting up
 
 ```
-npm create convex@latest -t react-vite-clerk-shadcn
+npx create-convex@latest -t react-vite-clerk-shadcn
 ```
 
 Then:


### PR DESCRIPTION
npm 11 broke passing through config flags with npm create.
Replaced 'npm create convex@latest --' with 'npx create-convex@latest'
and 'npm create convex --' with 'npx create-convex'.